### PR TITLE
chore: Update Streaming ACN acrynom to sACN

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Documentation coming soon.
 
 ***
 ### DMX Output
-Lumenarium supports SACN output, and ArtNet is in development, via a DMX system which underlies them both.
+Lumenarium supports sACN output, and ArtNet is in development, via a DMX system which underlies them both.
 
 ***
 ### Live Visualization


### PR DESCRIPTION
While technically, ANSI E1.31 - 2016 never states that the correct acrynom is `sACN`.. but the internet believes that to be the case =)